### PR TITLE
Revamp landing sections with Home 3 styling

### DIFF
--- a/src/app/components/landing/header/landing-header.tsx
+++ b/src/app/components/landing/header/landing-header.tsx
@@ -10,47 +10,47 @@ const LandingHeader = () => {
   const { user } = useAuth();
 
   return (
-    <header className="landing-header bg-light">
+    <header className="landing-hero">
       {user ? <NavbarAuthenticated /> : <NavbarUnauthenticated />}
-      <div className="container py-5">
-        <div className="row align-items-center gy-4">
-          <div className="col-lg-7">
-            <div className="d-flex flex-column gap-3">
-              <span className="badge bg-soft-primary text-primary align-self-start px-3 py-2 rounded-pill fw-semibold">
-                Business directory reimagined
-              </span>
-              <h1 className="display-5 fw-bold text-dark">
-                Find {user ? "your next client" : "businesses"} with confidence
-              </h1>
-              <p className="lead text-secondary">
-                Qtick Biz Profile connects customers with curated vendors across hospitality, wellness,
-                technology, and more. {user ? "Manage your presence and convert visits into bookings." : "Browse trusted listings, read real reviews, and unlock exclusive promotions."}
-              </p>
-              <div className="card border-0 shadow-sm rounded-4 advertising-slot" aria-label="Featured advertising">
-                <div className="card-body d-flex flex-column flex-md-row align-items-md-center gap-3">
-                  <div>
-                    <small className="text-uppercase text-muted fw-bold">Sponsored Highlight</small>
-                    <h6 className="mb-1 fw-semibold">Boost your visibility with VIP promotions</h6>
-                    <p className="mb-0 text-secondary small">
-                      Upgrade to a paid placement and appear in premium search results across Qtick.
-                    </p>
+      <div
+        className="landing-hero__banner image-cover"
+        style={{ backgroundImage: "url('/img/banner-6.jpg')" }}
+        data-overlay="6"
+      >
+        <div className="landing-hero__content container">
+          <div className="row align-items-center gy-4">
+            <div className="col-lg-7">
+              <div className="d-flex flex-column gap-3 text-white">
+                <span className="badge bg-soft-light text-white align-self-start px-3 py-2 rounded-pill fw-semibold">
+                  Business directory reimagined
+                </span>
+                <h1 className="display-5 fw-bold">
+                  Find {user ? "your next client" : "businesses"} with confidence
+                </h1>
+                <p className="lead text-white-50 mb-0">
+                  Qtick Biz Profile connects customers with curated vendors across hospitality, wellness,
+                  technology, and more. {user ? "Manage your presence and convert visits into bookings." : "Browse trusted listings, read real reviews, and unlock exclusive promotions."}
+                </p>
+                <div className="card border-0 shadow-sm rounded-4 advertising-slot mt-3" aria-label="Featured advertising">
+                  <div className="card-body d-flex flex-column flex-md-row align-items-md-center gap-3">
+                    <div>
+                      <small className="text-uppercase text-muted fw-bold">Sponsored Highlight</small>
+                      <h6 className="mb-1 fw-semibold text-dark">Boost your visibility with VIP promotions</h6>
+                      <p className="mb-0 text-secondary small">
+                        Upgrade to a paid placement and appear in premium search results across Qtick.
+                      </p>
+                    </div>
+                    <Link href="/pricing" className="btn btn-outline-primary ms-md-auto">
+                      View Plans
+                    </Link>
                   </div>
-                  <Link href="/pricing" className="btn btn-outline-primary ms-md-auto">
-                    View Plans
-                  </Link>
                 </div>
               </div>
             </div>
-          </div>
-          <div className="col-lg-5">
-            <SearchForm />
-            <div className="mt-3 p-3 bg-white rounded-4 shadow-sm" aria-live="polite">
-              <h6 className="fw-semibold mb-1">Why Qtick?</h6>
-              <ul className="list-unstyled mb-0 text-secondary small">
-                <li>Verified reviews keep quality front and centre.</li>
-                <li>Smart filters deliver results based on your location and intent.</li>
-                <li>Vendors gain actionable insights and lead generation tools.</li>
-              </ul>
+            <div className="col-lg-5 ms-lg-auto">
+              <div className="landing-hero__form">
+                <SearchForm />
+              </div>
             </div>
           </div>
         </div>

--- a/src/app/components/landing/popular-businesses.tsx
+++ b/src/app/components/landing/popular-businesses.tsx
@@ -1,15 +1,47 @@
 "use client";
 
+import Image from "next/image";
+import Link from "next/link";
 import { useMemo } from "react";
+import { BsBriefcase, BsGeoAlt, BsPatchCheckFill, BsStar, BsSuitHeart } from "react-icons/bs";
+import { Swiper, SwiperSlide } from "swiper/react";
+import { Autoplay, Pagination } from "swiper/modules";
 
-import { landingBusinesses } from "../../data/landing";
-import BusinessCard from "./business-card";
+import { landingBusinesses, landingCategories } from "../../data/landing";
 import { useAuth } from "../providers/auth-context";
 import { useSearch } from "../search/search-context";
+
+import "swiper/css";
+import "swiper/css/pagination";
+
+const ratingClass = (rating: number) => {
+  if (rating >= 4.7) {
+    return "excellent";
+  }
+  if (rating >= 4.4) {
+    return "good";
+  }
+  if (rating >= 4.0) {
+    return "midium";
+  }
+  return "poor";
+};
 
 const PopularBusinesses = () => {
   const { user } = useAuth();
   const { results, query } = useSearch();
+
+  const categoryLookup = useMemo(() => {
+    const entries = landingCategories.map((category, index) => [
+      category.id,
+      {
+        icon: category.icon,
+        name: category.name,
+        style: `cats-${(index % 10) + 1}`,
+      },
+    ] as const);
+    return new Map(entries);
+  }, []);
 
   const businesses = useMemo(() => {
     const paidListings = landingBusinesses.filter((business) => business.isPaid);
@@ -34,29 +66,142 @@ const PopularBusinesses = () => {
   }, [user]);
 
   return (
-    <section className="py-5 bg-light" id="popular">
+    <section className="py-5 light-top-gredient" id="popular">
       <div className="container">
-        <div className="row mb-4">
-          <div className="col-lg-8">
-            <h2 className="fw-bold">Most popular businesses</h2>
-            {user ? (
-              <p className="text-secondary mb-0">
-                Curated for you using paid listings and your recent interests in {query.keywords || "various services"}.
-              </p>
-            ) : (
-              <p className="text-secondary mb-0">
-                Discover trending premium vendors selected from our featured partners.
-              </p>
-            )}
+        <div className="row align-items-center justify-content-center mb-4">
+          <div className="col-xl-7 col-lg-8 col-md-11 col-sm-12">
+            <div className="secHeading-wrap text-center">
+              <h3 className="sectionHeading">
+                Trending &amp; Popular <span className="text-primary">Listings</span>
+              </h3>
+              <p>Explore Hot &amp; Popular Business Listings</p>
+            </div>
           </div>
         </div>
-        <div className="row g-4">
-          {businesses.map((business) => (
-            <div className="col-md-6 col-lg-4" key={business.id}>
-              <BusinessCard business={business} />
-            </div>
-          ))}
+
+        <div className="row align-items-center justify-content-center">
+          <div className="col-xl-12">
+            <Swiper
+              slidesPerView={4}
+              spaceBetween={15}
+              modules={[Autoplay, Pagination]}
+              pagination={{ clickable: true }}
+              loop={true}
+              autoplay={{ delay: 2000, disableOnInteraction: false }}
+              breakpoints={{
+                0: { slidesPerView: 1 },
+                640: { slidesPerView: 2 },
+                1024: { slidesPerView: 3 },
+                1440: { slidesPerView: 4 },
+              }}
+            >
+              {businesses.map((business) => {
+                const primaryCategoryId = business.categories[0];
+                const categoryMeta = primaryCategoryId ? categoryLookup.get(primaryCategoryId) : undefined;
+                const CategoryIcon = categoryMeta?.icon ?? BsBriefcase;
+                const categoryName = categoryMeta?.name ?? "Featured";
+                const categoryStyle = categoryMeta?.style ?? "";
+
+                return (
+                  <SwiperSlide className="singleItem" key={business.id}>
+                    <div className="listingitem-container">
+                      <div className="singlelisting-item">
+                        <div className="listing-top-item">
+                          <Link
+                            href={`/single-listing-01?listing=${business.slug}`}
+                            className="topLink"
+                            aria-label={`View details for ${business.name}`}
+                          >
+                            <div className="position-absolute start-0 top-0 ms-3 mt-3 z-2">
+                              <div className="d-flex align-items-center justify-content-start gap-2 flex-wrap">
+                                <span className="badge badge-xs text-uppercase listOpen">Premium</span>
+                                <span className="badge badge-xs badge-transparent">
+                                  <BsStar className="me-1" aria-hidden={true} />
+                                  {business.rating.toFixed(1)}
+                                </span>
+                                {business.isPaid && (
+                                  <span className="badge badge-xs badge-transparent">
+                                    <BsPatchCheckFill className="me-1" aria-hidden={true} /> Featured
+                                  </span>
+                                )}
+                              </div>
+                            </div>
+                            <Image
+                              src={business.heroImage}
+                              width={600}
+                              height={420}
+                              sizes="(max-width: 768px) 100vw, 33vw"
+                              className="img-fluid"
+                              alt={business.name}
+                            />
+                          </Link>
+                          <div className="position-absolute end-0 bottom-0 me-3 mb-3 z-2">
+                            <Link
+                              href={`/single-listing-01?listing=${business.slug}`}
+                              className="bookmarkList"
+                              data-bs-toggle="tooltip"
+                              data-bs-title="Save Listing"
+                              aria-label={`Save ${business.name}`}
+                            >
+                              <BsSuitHeart className="m-0" />
+                            </Link>
+                          </div>
+                        </div>
+                        <div className="listing-middle-item">
+                            <div className="listing-avatar">
+                              <div className="avatarImg d-flex align-items-center justify-content-center bg-white">
+                                <CategoryIcon aria-hidden={true} size={22} />
+                              </div>
+                            </div>
+                          <div className="listing-details">
+                            <h4 className="listingTitle">
+                              <Link href={`/single-listing-01?listing=${business.slug}`} className="titleLink">
+                                {business.name}
+                                <span className="verified">
+                                  <BsPatchCheckFill className="m-0" aria-hidden={true} />
+                                </span>
+                              </Link>
+                            </h4>
+                            <p>{business.tagline}</p>
+                          </div>
+                          <div className="listing-info-details">
+                            <div className="d-flex align-items-center justify-content-start gap-2">
+                              <div className="list-distance">
+                                <BsGeoAlt className="mb-0 me-2" aria-hidden={true} />
+                                {business.location}
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div className="listing-footer-item">
+                          <div className="d-flex align-items-center justify-content-between gap-2">
+                            <div className="catdWraps">
+                              <div className="flex-start">
+                                <span className={`catIcon ${categoryStyle}`}>
+                                  <CategoryIcon aria-hidden={true} size={18} />
+                                </span>
+                                <span className="catTitle ms-2">{categoryName}</span>
+                              </div>
+                            </div>
+                            <div className="listing-rates">
+                              <div className="d-flex align-items-center justify-content-start gap-1">
+                                <span className={`ratingAvarage ${ratingClass(business.rating)}`}>
+                                  {business.rating.toFixed(1)}
+                                </span>
+                                <span className="overallrates">{business.reviewCount} reviews</span>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </SwiperSlide>
+                );
+              })}
+            </Swiper>
+          </div>
         </div>
+
         {results.length > 0 && (
           <div className="alert alert-success mt-4" role="status">
             We used your latest search for <strong>{query.keywords}</strong> in {" "}

--- a/src/app/components/landing/search/search-section.tsx
+++ b/src/app/components/landing/search/search-section.tsx
@@ -1,82 +1,169 @@
 "use client";
 
+import Image from "next/image";
 import Link from "next/link";
+import { useMemo } from "react";
+import { useRouter } from "next/navigation";
+import { Swiper, SwiperSlide } from "swiper/react";
+import { Autoplay } from "swiper/modules";
 
 import { landingCategories } from "../../../data/landing";
 import BusinessCard from "../business-card";
 import { useSearch } from "../../search/search-context";
 
+import "swiper/css";
+
+const CATEGORY_IMAGES = [
+  "/img/cats/catt-1.jpg",
+  "/img/cats/catt-2.jpg",
+  "/img/cats/catt-3.jpg",
+  "/img/cats/catt-4.jpg",
+  "/img/cats/catt-5.jpg",
+  "/img/cats/catt-6.jpg",
+  "/img/cats/catt-7.jpg",
+  "/img/cats/catt-8.jpg",
+];
+
 const SearchSection = () => {
+  const router = useRouter();
   const { results, query, isSearching, clearSearch } = useSearch();
+
   const hasQuery = Boolean(query.location.trim() || query.keywords.trim());
   const hasResults = results.length > 0;
 
+  const trendingCategories = useMemo(
+    () =>
+      landingCategories.map((category, index) => ({
+        ...category,
+        image: CATEGORY_IMAGES[index % CATEGORY_IMAGES.length],
+      })),
+    []
+  );
+
+  const handleCategoryNavigate = (slug: string) => {
+    router.push(`/list-layout-01?category=${slug}`);
+  };
+
   return (
-    <section className="py-5" aria-live="polite">
+    <section className="py-5 bg-white" id="categories" aria-live="polite">
       <div className="container">
-        <div className="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2 mb-4">
-          <div>
-            <h2 className="fw-bold mb-1">Search results</h2>
-            {hasQuery ? (
-              <p className="mb-0 text-secondary">
-                Showing matches for <strong>{query.keywords || "all services"}</strong> in {" "}
-                <strong>{query.location || "all locations"}</strong>
-              </p>
-            ) : (
-              <p className="mb-0 text-secondary">Use the search box above to explore businesses.</p>
-            )}
+        <div className="row align-items-center justify-content-center mb-4">
+          <div className="col-xl-7 col-lg-8 col-md-11 col-sm-12">
+            <div className="secHeading-wrap text-center">
+              <h3 className="sectionHeading">
+                Hot &amp; Trending <span className="text-primary">Categories</span>
+              </h3>
+              <p>Explore all types of popular category for submit your listings</p>
+            </div>
           </div>
-          {hasQuery && (
-            <button type="button" className="btn btn-sm btn-outline-secondary" onClick={clearSearch}>
-              Clear search
-            </button>
-          )}
         </div>
 
-        {isSearching && <div className="alert alert-info">Searching businesses...</div>}
+        <div className="row align-items-center justify-content-center">
+          <div className="col-xl-12">
+            <Swiper
+              slidesPerView={6}
+              spaceBetween={24}
+              modules={[Autoplay]}
+              loop={true}
+              autoplay={{ delay: 2200, disableOnInteraction: false }}
+              breakpoints={{
+                0: { slidesPerView: 1 },
+                576: { slidesPerView: 2 },
+                768: { slidesPerView: 3 },
+                992: { slidesPerView: 4 },
+                1200: { slidesPerView: 5 },
+                1400: { slidesPerView: 6 },
+              }}
+            >
+              {trendingCategories.map((category) => {
+                const Icon = category.icon;
+                return (
+                  <SwiperSlide className="singleCategory" key={category.id}>
+                    <button
+                      type="button"
+                      className="categoryBox"
+                      onClick={() => handleCategoryNavigate(category.slug)}
+                      aria-label={`Browse ${category.name}`}
+                    >
+                      <div className="categoryCapstions">
+                        <div className="catsIcons">
+                          <div className="icoBoxx">
+                            <Icon aria-hidden={true} />
+                          </div>
+                        </div>
+                        <div className="catsTitle">
+                          <h5>{category.name}</h5>
+                        </div>
+                        <div className="CatsLists">
+                          <span className="categorycounter">{category.description}</span>
+                        </div>
+                      </div>
+                      <Image
+                        src={category.image}
+                        width={400}
+                        height={260}
+                        className="img-fluid"
+                        alt={`${category.name} background`}
+                      />
+                    </button>
+                  </SwiperSlide>
+                );
+              })}
+            </Swiper>
+          </div>
+        </div>
 
-        {hasQuery ? (
-          hasResults ? (
-            <div className="row g-4">
-              {results.map((business) => (
-                <div className="col-md-6 col-lg-4" key={business.id}>
-                  <BusinessCard business={business} />
-                </div>
-              ))}
-            </div>
-          ) : (
-            <div className="alert alert-warning" role="status">
-              No listings matched your filters. Try broadening your keywords or browsing by category below.
-            </div>
-          )
-        ) : (
-          <div className="row g-3" role="list">
-            {landingCategories.slice(0, 6).map((category) => (
-              <div className="col-6 col-md-4 col-lg-3" key={category.id} role="listitem">
-                <div className="border rounded-4 p-3 h-100">
-                  <category.icon className="text-primary mb-2" size={24} aria-hidden={true} />
-                  <h6 className="fw-semibold mb-1">{category.name}</h6>
-                  <p className="text-secondary small mb-0">{category.description}</p>
-                </div>
+        {hasQuery && (
+          <div className="mt-5">
+            <div className="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2 mb-4">
+              <div>
+                <h2 className="fw-bold mb-1">Search results</h2>
+                <p className="mb-0 text-secondary">
+                  Showing matches for <strong>{query.keywords || "all services"}</strong> in {" "}
+                  <strong>{query.location || "all locations"}</strong>
+                </p>
               </div>
-            ))}
+              <button type="button" className="btn btn-sm btn-outline-secondary" onClick={clearSearch}>
+                Clear search
+              </button>
+            </div>
+
+            {isSearching && <div className="alert alert-info">Searching businesses...</div>}
+
+            {hasResults ? (
+              <div className="row g-4">
+                {results.map((business) => (
+                  <div className="col-md-6 col-lg-4" key={business.id}>
+                    <BusinessCard business={business} />
+                  </div>
+                ))}
+              </div>
+            ) : (
+              !isSearching && (
+                <div className="alert alert-warning" role="status">
+                  No listings matched your filters. Try broadening your keywords or exploring another category above.
+                </div>
+              )
+            )}
           </div>
         )}
 
-        <div className="mt-4">
-          <h6 className="fw-semibold">Related tools</h6>
-          <div className="d-flex flex-wrap gap-2">
-            <Link href="#promotions" className="badge bg-soft-primary text-primary rounded-pill px-3 py-2">
-              View VIP promotions
-            </Link>
-            <Link href="#testimonials" className="badge bg-soft-primary text-primary rounded-pill px-3 py-2">
-              Hear from customers
-            </Link>
-            <Link href="#news" className="badge bg-soft-primary text-primary rounded-pill px-3 py-2">
-              Explore platform news
-            </Link>
+        {!hasQuery && !isSearching && (
+          <div className="mt-4">
+            <h6 className="fw-semibold">Related tools</h6>
+            <div className="d-flex flex-wrap gap-2">
+              <Link href="#promotions" className="badge bg-soft-primary text-primary rounded-pill px-3 py-2">
+                View VIP promotions
+              </Link>
+              <Link href="#testimonials" className="badge bg-soft-primary text-primary rounded-pill px-3 py-2">
+                Hear from customers
+              </Link>
+              <Link href="#news" className="badge bg-soft-primary text-primary rounded-pill px-3 py-2">
+                Explore platform news
+              </Link>
+            </div>
           </div>
-        </div>
+        )}
       </div>
     </section>
   );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -21,8 +21,34 @@
   transform: translateY(-2px);
 }
 
-.landing-header .advertising-slot {
+.landing-header .advertising-slot,
+.landing-hero .advertising-slot {
   border-left: 4px solid var(--bs-primary);
+}
+
+.landing-hero__banner {
+  position: relative;
+  min-height: 50vh;
+  display: flex;
+  align-items: center;
+  padding: 4rem 0;
+}
+
+.landing-hero__content {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+}
+
+.landing-hero__form {
+  max-width: 420px;
+  margin-left: auto;
+}
+
+@media (max-width: 991.98px) {
+  .landing-hero__form {
+    margin-left: 0;
+  }
 }
 
 .vendor-hero {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,5 @@
 import LandingHeader from "./components/landing/header/landing-header";
 import SearchSection from "./components/landing/search/search-section";
-import CategoryGrid from "./components/landing/category-grid";
 import PopularBusinesses from "./components/landing/popular-businesses";
 import TestimonialsSection from "./components/landing/testimonials-section";
 import RecentActivities from "./components/landing/recent-activities";
@@ -15,7 +14,6 @@ export default function Home() {
     <SearchProvider>
       <LandingHeader />
       <SearchSection />
-      <CategoryGrid />
       <PopularBusinesses />
       <TestimonialsSection />
       <RecentActivities />


### PR DESCRIPTION
## Summary
- restyle the landing hero to match the Home 3 banner with a 50% height cover image and overlay
- combine the search results and category carousel into a single "Hot & Trending Categories" section using Home 3 card styling
- replace the popular business grid with a Home 3 inspired Swiper carousel that keeps search personalization messaging

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_b_68c8f7b85e4c832e97df279ff73d2a81