### PR TITLE
Revamp landing search workflow and add listings demo

### DIFF
--- a/src/app/components/footer/footer.tsx
+++ b/src/app/components/footer/footer.tsx
@@ -100,7 +100,7 @@ export default function Footer() {
             </div>
             <div className="container-fluid border-top pt-3 pb-3">
                 <div className="d-flex flex-column flex-md-row align-items-md-center justify-content-md-between gap-3">
-                    <p className="mb-0 small text-muted">Stay connected with Qtick for industry insights, compliance updates, and community stories.</p>
+                    <p className="mb-0 small text-muted">Stay connected with QTick for industry insights, compliance updates, and community stories.</p>
                     <div className="d-flex flex-wrap gap-2">
                         <Link href="/list-layout-01" className="badge bg-soft-primary text-primary rounded-pill">Browse Listings</Link>
                         <Link href="/dashboard-add-listing" className="badge bg-soft-primary text-primary rounded-pill">Add Your Business</Link>

--- a/src/app/components/landing/header/brand.tsx
+++ b/src/app/components/landing/header/brand.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link";
+
+interface BrandProps {
+  className?: string;
+}
+
+const Brand = ({ className = "" }: BrandProps) => {
+  const classes = [
+    "navbar-brand",
+    "d-inline-flex",
+    "align-items-center",
+    "gap-2",
+    "text-decoration-none",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <Link href="/" className={classes} aria-label="QTick home">
+      <span className="brand-placeholder" aria-hidden={true}>
+        Logo
+      </span>
+      <span className="fw-bold fs-4 text-primary mb-0">QTick</span>
+    </Link>
+  );
+};
+
+export default Brand;

--- a/src/app/components/landing/header/landing-header.tsx
+++ b/src/app/components/landing/header/landing-header.tsx
@@ -19,7 +19,7 @@ const LandingHeader = () => {
       >
         <div className="landing-hero__content container">
           <div className="row align-items-center gy-4">
-            <div className="col-lg-7">
+            <div className="col-lg-6 col-xl-5">
               <div className="d-flex flex-column gap-3 text-white">
                 <span className="badge bg-soft-light text-white align-self-start px-3 py-2 rounded-pill fw-semibold">
                   Business directory reimagined
@@ -28,26 +28,20 @@ const LandingHeader = () => {
                   Find {user ? "your next client" : "businesses"} with confidence
                 </h1>
                 <p className="lead text-white-50 mb-0">
-                  Qtick Biz Profile connects customers with curated vendors across hospitality, wellness,
-                  technology, and more. {user ? "Manage your presence and convert visits into bookings." : "Browse trusted listings, read real reviews, and unlock exclusive promotions."}
+                  QTick connects customers with curated vendors across hospitality, wellness, technology, and more.
+                  {" "}
+                  {user
+                    ? "Manage your presence and convert visits into bookings."
+                    : "Browse trusted listings, read real reviews, and unlock exclusive promotions."}
                 </p>
-                <div className="card border-0 shadow-sm rounded-4 advertising-slot mt-3" aria-label="Featured advertising">
-                  <div className="card-body d-flex flex-column flex-md-row align-items-md-center gap-3">
-                    <div>
-                      <small className="text-uppercase text-muted fw-bold">Sponsored Highlight</small>
-                      <h6 className="mb-1 fw-semibold text-dark">Boost your visibility with VIP promotions</h6>
-                      <p className="mb-0 text-secondary small">
-                        Upgrade to a paid placement and appear in premium search results across Qtick.
-                      </p>
-                    </div>
-                    <Link href="/pricing" className="btn btn-outline-primary ms-md-auto">
-                      View Plans
-                    </Link>
-                  </div>
+                <div>
+                  <Link href="/pricing" className="btn btn-outline-light btn-sm text-uppercase fw-semibold px-4">
+                    View plans
+                  </Link>
                 </div>
               </div>
             </div>
-            <div className="col-lg-5 ms-lg-auto">
+            <div className="col-lg-6 col-xl-6 ms-xl-auto">
               <div className="landing-hero__form">
                 <SearchForm />
               </div>

--- a/src/app/components/landing/header/navbar-authenticated.tsx
+++ b/src/app/components/landing/header/navbar-authenticated.tsx
@@ -8,6 +8,7 @@ import { IoClose } from "react-icons/io5";
 import { BsChevronDown, BsDoorOpenFill } from "react-icons/bs";
 
 import { useAuth } from "../../providers/auth-context";
+import Brand from "./brand";
 
 interface NavItem {
   label: string;
@@ -16,6 +17,7 @@ interface NavItem {
 
 const navItems: NavItem[] = [
   { label: "Dashboard", href: "/dashboard-user" },
+  { label: "Demo", href: "/demo" },
   { label: "My Listings", href: "/dashboard-my-listings" },
   { label: "Categories", href: "#categories" },
   { label: "Support", href: "/help-center" },
@@ -30,9 +32,7 @@ const NavbarAuthenticated = () => {
     <div className="bg-white shadow-sm border-bottom">
       <div className="container py-3">
         <div className="d-flex align-items-center justify-content-between">
-          <Link href="/" className="navbar-brand fw-bold fs-4 text-primary">
-            Qtick Biz Profile
-          </Link>
+          <Brand />
           <button
             className="btn btn-link d-lg-none"
             aria-label={isMobileMenuOpen ? "Close navigation" : "Open navigation"}

--- a/src/app/components/landing/header/navbar-unauthenticated.tsx
+++ b/src/app/components/landing/header/navbar-unauthenticated.tsx
@@ -8,6 +8,7 @@ import { BsPersonPlus, BsBoxArrowInRight } from "react-icons/bs";
 
 import { useAuth } from "../../providers/auth-context";
 import type { User } from "../../../types/models";
+import Brand from "./brand";
 
 interface NavItem {
   label: string;
@@ -16,6 +17,7 @@ interface NavItem {
 
 const navItems: NavItem[] = [
   { label: "Home", href: "/" },
+  { label: "Demo", href: "/demo" },
   { label: "Vendors", href: "/list-layout-01" },
   { label: "Categories", href: "#categories" },
   { label: "Testimonials", href: "#testimonials" },
@@ -43,9 +45,7 @@ const NavbarUnauthenticated = () => {
     <div className="bg-white shadow-sm border-bottom">
       <div className="container py-3">
         <div className="d-flex align-items-center justify-content-between">
-          <Link href="/" className="navbar-brand fw-bold fs-4 text-primary">
-            Qtick Biz Profile
-          </Link>
+          <Brand />
           <button
             className="btn btn-link d-lg-none"
             aria-label={isMobileMenuOpen ? "Close navigation" : "Open navigation"}

--- a/src/app/components/landing/news-section.tsx
+++ b/src/app/components/landing/news-section.tsx
@@ -10,7 +10,7 @@ const NewsSection = () => {
           <div className="col-lg-8">
             <h2 className="fw-bold">Latest updates</h2>
             <p className="text-secondary mb-0">
-              Learn how Qtick is evolving and how to get the most from your business profile.
+              Learn how QTick is evolving and how to get the most from your business profile.
             </p>
           </div>
         </div>

--- a/src/app/components/landing/popular-businesses.tsx
+++ b/src/app/components/landing/popular-businesses.tsx
@@ -10,6 +10,7 @@ import { Autoplay, Pagination } from "swiper/modules";
 import { landingBusinesses, landingCategories } from "../../data/landing";
 import { useAuth } from "../providers/auth-context";
 import { useSearch } from "../search/search-context";
+import { isDefaultRatingRange } from "../../utils/search";
 
 import "swiper/css";
 import "swiper/css/pagination";
@@ -204,8 +205,15 @@ const PopularBusinesses = () => {
 
         {results.length > 0 && (
           <div className="alert alert-success mt-4" role="status">
-            We used your latest search for <strong>{query.keywords}</strong> in {" "}
-            <strong>{query.location}</strong> to prioritise similar businesses.
+            We used your latest search for <strong>{query.keywords || "all services"}</strong> in {" "}
+            <strong>{query.location || "all locations"}</strong>
+            {!isDefaultRatingRange(query.ratingRange) && (
+              <>
+                {" "}with ratings between {query.ratingRange[0].toFixed(1)}★ and {" "}
+                {query.ratingRange[1].toFixed(1)}★
+              </>
+            )}
+            {" "}to prioritise similar businesses.
           </div>
         )}
       </div>

--- a/src/app/components/landing/recent-activities.tsx
+++ b/src/app/components/landing/recent-activities.tsx
@@ -10,7 +10,7 @@ const RecentActivities = () => {
           <div className="col-lg-8">
             <h2 className="fw-bold">Recent activities &amp; resources</h2>
             <p className="text-secondary mb-0">
-              Stay informed with platform updates, community stories, and educational content from Qtick.
+              Stay informed with platform updates, community stories, and educational content from QTick.
             </p>
           </div>
         </div>

--- a/src/app/components/landing/search/search-form.tsx
+++ b/src/app/components/landing/search/search-form.tsx
@@ -1,26 +1,42 @@
 "use client";
 
 import { FormEvent, useEffect, useState } from "react";
+import Slider from "rc-slider";
+import "rc-slider/assets/index.css";
+import { useRouter } from "next/navigation";
 import { BsGeoAlt, BsSearch } from "react-icons/bs";
 
 import type { SearchFormValues } from "../../../types/models";
 import { useSearch } from "../../search/search-context";
+import {
+  createSearchParams,
+  normaliseSearchValues,
+} from "../../../utils/search";
 
 interface SearchFormProps {
   onSearch?: (values: SearchFormValues) => void;
 }
 
 const SearchForm = ({ onSearch }: SearchFormProps) => {
+  const router = useRouter();
   const { performSearch, isSearching, query } = useSearch();
-  const [formValues, setFormValues] = useState<SearchFormValues>(query);
-  const [errors, setErrors] = useState<Partial<Record<keyof SearchFormValues, string>>>({});
+  const [formValues, setFormValues] = useState<SearchFormValues>(() => ({
+    location: query.location,
+    keywords: query.keywords,
+    ratingRange: [...query.ratingRange],
+  }));
+  const [errors, setErrors] = useState<Partial<Record<"location" | "keywords", string>>>({});
 
   useEffect(() => {
-    setFormValues(query);
-  }, [query.location, query.keywords]);
+    setFormValues({
+      location: query.location,
+      keywords: query.keywords,
+      ratingRange: [...query.ratingRange],
+    });
+  }, [query.location, query.keywords, query.ratingRange[0], query.ratingRange[1]]);
 
   const validate = (values: SearchFormValues) => {
-    const validationErrors: Partial<Record<keyof SearchFormValues, string>> = {};
+    const validationErrors: Partial<Record<"location" | "keywords", string>> = {};
     if (!values.location.trim()) {
       validationErrors.location = "Please provide a city or region.";
     }
@@ -37,60 +53,138 @@ const SearchForm = ({ onSearch }: SearchFormProps) => {
     if (Object.keys(validationErrors).length > 0) {
       return;
     }
-    performSearch(formValues);
-    onSearch?.(formValues);
+
+    const searchValues = normaliseSearchValues(formValues);
+    performSearch(searchValues);
+
+    if (onSearch) {
+      onSearch(searchValues);
+    } else {
+      const params = createSearchParams(searchValues);
+      router.push(`/listings?${params.toString()}`);
+    }
+  };
+
+  const handleRatingChange = (value: number | number[]) => {
+    if (!Array.isArray(value)) {
+      return;
+    }
+
+    setFormValues((previous) => ({
+      ...previous,
+      ratingRange: [Number(value[0]), Number(value[1])] as [number, number],
+    }));
   };
 
   return (
-    <form className="p-4 bg-white shadow rounded-4" onSubmit={handleSubmit} aria-label="Business search">
-      <div className="mb-3">
-        <label htmlFor="search-location" className="form-label fw-semibold">
-          Location
-        </label>
-        <div className="input-group">
-          <span className="input-group-text bg-white">
-            <BsGeoAlt />
-          </span>
-          <input
-            id="search-location"
-            name="location"
-            type="text"
-            className={`form-control ${errors.location ? "is-invalid" : ""}`}
-            placeholder="City, region, or postcode"
-            value={formValues.location}
-            onChange={(event) =>
-              setFormValues((previous) => ({ ...previous, location: event.target.value }))
-            }
-          />
-          {errors.location && <div className="invalid-feedback">{errors.location}</div>}
+    <form className="heroSearch style-01 shadow-sm" onSubmit={handleSubmit} aria-label="Business search">
+      <div className="row gx-lg-2 gx-md-2 gx-3 gy-sm-2 gy-2">
+        <div className="col-xl-10 col-lg-9 col-md-12">
+          <div className="row gx-lg-2 gx-md-2 gx-3 gy-sm-2 gy-2">
+            <div className="col-xl-6 col-lg-6 col-md-12 col-sm-12">
+              <div className="form-group">
+                <label htmlFor="search-keywords" className="form-label fw-semibold text-dark visually-hidden">
+                  What are you looking for?
+                </label>
+                <div className="mobSearch d-flex align-items-center justify-content-start">
+                  <div className="flexStart ps-2 d-flex align-items-center gap-2">
+                    <BsSearch className="text-primary" aria-hidden={true} />
+                    <span className="fw-semibold text-dark">Find</span>
+                  </div>
+                  <input
+                    id="search-keywords"
+                    name="keywords"
+                    type="text"
+                    className={`form-control fs-6 fw-medium border-0 flex-grow-1 ${
+                      errors.keywords ? "is-invalid" : ""
+                    }`}
+                    placeholder="What are you looking for?"
+                    value={formValues.keywords}
+                    onChange={(event) => {
+                      const { value } = event.target;
+                      setFormValues((previous) => ({ ...previous, keywords: value }));
+                      setErrors((previous) => ({ ...previous, keywords: undefined }));
+                    }}
+                    aria-invalid={Boolean(errors.keywords)}
+                    autoComplete="off"
+                  />
+                </div>
+                {errors.keywords && (
+                  <div className="invalid-feedback d-block">{errors.keywords}</div>
+                )}
+              </div>
+            </div>
+            <div className="col-xl-6 col-lg-6 col-md-12 col-sm-12 single-border">
+              <div className="form-group">
+                <label htmlFor="search-location" className="form-label fw-semibold text-dark visually-hidden">
+                  Where should we search?
+                </label>
+                <div className="mobSearch d-flex align-items-center justify-content-start">
+                  <div className="flexStart ps-2 d-flex align-items-center gap-2">
+                    <BsGeoAlt className="text-primary" aria-hidden={true} />
+                    <span className="fw-semibold text-dark">Where</span>
+                  </div>
+                  <input
+                    id="search-location"
+                    name="location"
+                    type="text"
+                    className={`form-control fs-6 fw-medium border-0 flex-grow-1 ${
+                      errors.location ? "is-invalid" : ""
+                    }`}
+                    placeholder="City, region, or postcode"
+                    value={formValues.location}
+                    onChange={(event) => {
+                      const { value } = event.target;
+                      setFormValues((previous) => ({ ...previous, location: value }));
+                      setErrors((previous) => ({ ...previous, location: undefined }));
+                    }}
+                    aria-invalid={Boolean(errors.location)}
+                    autoComplete="off"
+                  />
+                </div>
+                {errors.location && (
+                  <div className="invalid-feedback d-block">{errors.location}</div>
+                )}
+              </div>
+            </div>
+            <div className="col-12">
+              <div className="form-group mb-0">
+                <label className="form-label fw-semibold text-dark" id="rating-range-label">
+                  Rating range
+                </label>
+                <div className="searchBar-single-wrap rating-range-control mt-2">
+                  <Slider
+                    range
+                    min={0}
+                    max={5}
+                    step={0.5}
+                    value={formValues.ratingRange}
+                    onChange={handleRatingChange}
+                    allowCross={false}
+                    ariaLabelForHandle={["Minimum rating", "Maximum rating"]}
+                    ariaValueTextFormatter={(value) => `${value.toFixed(1)} stars`}
+                  />
+                  <div className="rating-range__labels mt-2">
+                    <span>Min: {formValues.ratingRange[0].toFixed(1)} ★</span>
+                    <span>Max: {formValues.ratingRange[1].toFixed(1)} ★</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
-      </div>
-      <div className="mb-3">
-        <label htmlFor="search-keywords" className="form-label fw-semibold">
-          Keywords
-        </label>
-        <div className="input-group">
-          <span className="input-group-text bg-white">
-            <BsSearch />
-          </span>
-          <input
-            id="search-keywords"
-            name="keywords"
-            type="text"
-            className={`form-control ${errors.keywords ? "is-invalid" : ""}`}
-            placeholder="Service, business, or category"
-            value={formValues.keywords}
-            onChange={(event) =>
-              setFormValues((previous) => ({ ...previous, keywords: event.target.value }))
-            }
-          />
-          {errors.keywords && <div className="invalid-feedback">{errors.keywords}</div>}
+        <div className="col-xl-2 col-lg-3 col-md-12 col-sm-12">
+          <div className="form-group h-100 d-flex align-items-stretch">
+            <button
+              type="submit"
+              className="btn btn-primary rounded-pill full-width fw-medium w-100"
+              disabled={isSearching}
+            >
+              <BsSearch className="me-2" aria-hidden={true} />
+              {isSearching ? "Searching..." : "Search"}
+            </button>
+          </div>
         </div>
-      </div>
-      <div className="d-grid">
-        <button type="submit" className="btn btn-primary" disabled={isSearching}>
-          <BsSearch className="me-2" /> {isSearching ? "Searching..." : "Search"}
-        </button>
       </div>
     </form>
   );

--- a/src/app/components/landing/search/search-form.tsx
+++ b/src/app/components/landing/search/search-form.tsx
@@ -162,7 +162,7 @@ const SearchForm = ({ onSearch }: SearchFormProps) => {
                     onChange={handleRatingChange}
                     allowCross={false}
                     ariaLabelForHandle={["Minimum rating", "Maximum rating"]}
-                    ariaValueTextFormatter={(value) => `${value.toFixed(1)} stars`}
+                    ariaValueTextFormatterForHandle={(value) => `${value.toFixed(1)} stars`}
                   />
                   <div className="rating-range__labels mt-2">
                     <span>Min: {formValues.ratingRange[0].toFixed(1)} ★</span>

--- a/src/app/components/landing/search/search-section.tsx
+++ b/src/app/components/landing/search/search-section.tsx
@@ -8,8 +8,6 @@ import { Swiper, SwiperSlide } from "swiper/react";
 import { Autoplay } from "swiper/modules";
 
 import { landingCategories } from "../../../data/landing";
-import BusinessCard from "../business-card";
-import { useSearch } from "../../search/search-context";
 
 import "swiper/css";
 
@@ -26,10 +24,6 @@ const CATEGORY_IMAGES = [
 
 const SearchSection = () => {
   const router = useRouter();
-  const { results, query, isSearching, clearSearch } = useSearch();
-
-  const hasQuery = Boolean(query.location.trim() || query.keywords.trim());
-  const hasResults = results.length > 0;
 
   const trendingCategories = useMemo(
     () =>
@@ -113,57 +107,20 @@ const SearchSection = () => {
           </div>
         </div>
 
-        {hasQuery && (
-          <div className="mt-5">
-            <div className="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2 mb-4">
-              <div>
-                <h2 className="fw-bold mb-1">Search results</h2>
-                <p className="mb-0 text-secondary">
-                  Showing matches for <strong>{query.keywords || "all services"}</strong> in {" "}
-                  <strong>{query.location || "all locations"}</strong>
-                </p>
-              </div>
-              <button type="button" className="btn btn-sm btn-outline-secondary" onClick={clearSearch}>
-                Clear search
-              </button>
-            </div>
-
-            {isSearching && <div className="alert alert-info">Searching businesses...</div>}
-
-            {hasResults ? (
-              <div className="row g-4">
-                {results.map((business) => (
-                  <div className="col-md-6 col-lg-4" key={business.id}>
-                    <BusinessCard business={business} />
-                  </div>
-                ))}
-              </div>
-            ) : (
-              !isSearching && (
-                <div className="alert alert-warning" role="status">
-                  No listings matched your filters. Try broadening your keywords or exploring another category above.
-                </div>
-              )
-            )}
+        <div className="mt-4">
+          <h6 className="fw-semibold">Featured marketplace tools</h6>
+          <div className="d-flex flex-wrap gap-2">
+            <Link href="#promotions" className="badge bg-soft-primary text-primary rounded-pill px-3 py-2">
+              View VIP promotions
+            </Link>
+            <Link href="#testimonials" className="badge bg-soft-primary text-primary rounded-pill px-3 py-2">
+              Hear from customers
+            </Link>
+            <Link href="#news" className="badge bg-soft-primary text-primary rounded-pill px-3 py-2">
+              Explore platform news
+            </Link>
           </div>
-        )}
-
-        {!hasQuery && !isSearching && (
-          <div className="mt-4">
-            <h6 className="fw-semibold">Related tools</h6>
-            <div className="d-flex flex-wrap gap-2">
-              <Link href="#promotions" className="badge bg-soft-primary text-primary rounded-pill px-3 py-2">
-                View VIP promotions
-              </Link>
-              <Link href="#testimonials" className="badge bg-soft-primary text-primary rounded-pill px-3 py-2">
-                Hear from customers
-              </Link>
-              <Link href="#news" className="badge bg-soft-primary text-primary rounded-pill px-3 py-2">
-                Explore platform news
-              </Link>
-            </div>
-          </div>
-        )}
+        </div>
       </div>
     </section>
   );

--- a/src/app/components/landing/testimonials-section.tsx
+++ b/src/app/components/landing/testimonials-section.tsx
@@ -24,9 +24,9 @@ const TestimonialsSection = () => {
       <div className="container">
         <div className="row align-items-start g-4">
           <div className="col-lg-5">
-            <h2 className="fw-bold">What people say about Qtick</h2>
+            <h2 className="fw-bold">What people say about QTick</h2>
             <p className="text-secondary">
-              Real reviews from vendors and customers demonstrate how Qtick drives trust and growth on both
+              Real reviews from vendors and customers demonstrate how QTick drives trust and growth on both
               sides of the marketplace.
             </p>
             <div className="d-flex gap-2 mt-3">

--- a/src/app/data/landing.ts
+++ b/src/app/data/landing.ts
@@ -413,7 +413,7 @@ export const landingTestimonials: Testimonial[] = [
     author: "Daniel Reed",
     role: "Vendor Partner",
     rating: 5,
-    content: "Qtick helped us reach a 30% increase in qualified leads within the first month.",
+    content: "QTick helped us reach a 30% increase in qualified leads within the first month.",
     avatar: "/img/team-2.jpg",
   },
   {
@@ -437,7 +437,7 @@ export const landingTestimonials: Testimonial[] = [
 export const landingActivities: Activity[] = [
   {
     id: "activity-1",
-    title: "Qtick launches vendor academy",
+    title: "QTick launches vendor academy",
     description: "Upskill with on-demand workshops on brand storytelling and lead nurturing.",
     publishedOn: "2024-12-05",
     category: "Announcement",
@@ -491,7 +491,7 @@ export const landingPromotions: Promotion[] = [
 export const landingNews: NewsArticle[] = [
   {
     id: "news-1",
-    title: "How Qtick personalises discovery for returning users",
+    title: "How QTick personalises discovery for returning users",
     excerpt: "Understand the data signals that power our recommendation engine.",
     publishedOn: "2024-12-12",
     link: "#",

--- a/src/app/demo/page.tsx
+++ b/src/app/demo/page.tsx
@@ -1,0 +1,103 @@
+import Link from "next/link";
+
+import NavbarUnauthenticated from "../components/landing/header/navbar-unauthenticated";
+import Footer from "../components/footer/footer";
+import BackToTop from "../components/back-to-top";
+
+const demoPages = [
+  {
+    title: "Home Layout 01",
+    href: "/",
+    description: "Hero search with testimonials and featured businesses.",
+  },
+  {
+    title: "Home Layout 09",
+    href: "/home-9",
+    description: "Lifestyle splash layout with pill-style search controls.",
+  },
+  {
+    title: "Listings (Smart Search)",
+    href: "/listings",
+    description: "Grid results powered by the slider-enabled search experience.",
+  },
+  {
+    title: "Grid Layout 01",
+    href: "/grid-layout-01",
+    description: "Classic card grid with sidebar filters and pagination.",
+  },
+  {
+    title: "Grid Layout 04",
+    href: "/grid-layout-04",
+    description: "Wide image cards and subtle hover states for visual brands.",
+  },
+  {
+    title: "List Layout 01",
+    href: "/list-layout-01",
+    description: "Stacked listings with category chips and quick actions.",
+  },
+  {
+    title: "Half Map Screen 01",
+    href: "/half-map-01",
+    description: "Split map and list view ideal for location-first browsing.",
+  },
+  {
+    title: "Vendor Dashboard",
+    href: "/dashboard-user",
+    description: "Signed-in vendor workspace with performance insights.",
+  },
+  {
+    title: "Pricing & Plans",
+    href: "/pricing",
+    description: "Subscription tiers highlighting features and value props.",
+  },
+];
+
+const DemoPage = () => {
+  return (
+    <>
+      <NavbarUnauthenticated />
+
+      <section className="py-5 bg-light border-bottom">
+        <div className="container">
+          <div className="row justify-content-center text-center">
+            <div className="col-lg-8 col-md-10">
+              <span className="badge bg-soft-primary text-primary rounded-pill px-3 py-2 fw-semibold">
+                Explore the library
+              </span>
+              <h1 className="display-5 fw-bold mt-3">Preview every QTick demo in one place</h1>
+              <p className="lead text-secondary">
+                Jump between home pages, listing grids, map views, and dashboards to choose the perfect starting point for your
+                experience.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-5">
+        <div className="container">
+          <div className="row g-4">
+            {demoPages.map((page) => (
+              <div className="col-md-6 col-lg-4" key={page.href}>
+                <div className="card h-100 shadow-sm border-0">
+                  <div className="card-body d-flex flex-column gap-2">
+                    <h5 className="fw-semibold mb-1">{page.title}</h5>
+                    <p className="text-secondary mb-0">{page.description}</p>
+                    <Link href={page.href} className="btn btn-outline-primary mt-auto align-self-start">
+                      View page
+                    </Link>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <Footer />
+      <BackToTop />
+    </>
+  );
+};
+
+export default DemoPage;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -28,10 +28,10 @@
 
 .landing-hero__banner {
   position: relative;
-  min-height: 50vh;
+  min-height: 650px;
   display: flex;
   align-items: center;
-  padding: 4rem 0;
+  padding: 5rem 0;
 }
 
 .landing-hero__content {
@@ -41,7 +41,7 @@
 }
 
 .landing-hero__form {
-  max-width: 420px;
+  max-width: 100%;
   margin-left: auto;
 }
 
@@ -49,6 +49,42 @@
   .landing-hero__form {
     margin-left: 0;
   }
+}
+
+.brand-placeholder {
+  width: 48px;
+  height: 48px;
+  border-radius: 12px;
+  border: 2px dashed rgba(13, 110, 253, 0.4);
+  background-color: rgba(13, 110, 253, 0.08);
+  color: var(--bs-primary);
+  font-weight: 600;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.rating-range-control .rc-slider {
+  padding: 0 12px;
+}
+
+.rating-range-control .rc-slider-track {
+  background-color: var(--bs-primary);
+}
+
+.rating-range-control .rc-slider-handle {
+  border-color: var(--bs-primary);
+  box-shadow: none;
+}
+
+.rating-range__labels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.875rem;
+  color: rgba(33, 37, 41, 0.7);
 }
 
 .vendor-hero {

--- a/src/app/listings/page.tsx
+++ b/src/app/listings/page.tsx
@@ -1,0 +1,275 @@
+"use client";
+
+import { useEffect, useMemo } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import {
+  BsGeoAlt,
+  BsPatchCheckFill,
+  BsSearch,
+  BsStar,
+  BsSuitHeart,
+} from "react-icons/bs";
+
+import NavbarUnauthenticated from "../components/landing/header/navbar-unauthenticated";
+import Footer from "../components/footer/footer";
+import BackToTop from "../components/back-to-top";
+import SearchForm from "../components/landing/search/search-form";
+import { SearchProvider, useSearch } from "../components/search/search-context";
+import { landingBusinesses, landingCategories } from "../data/landing";
+import type { SearchFormValues } from "../types/models";
+import {
+  createSearchParams,
+  isDefaultRatingRange,
+  parseSearchParams,
+} from "../utils/search";
+
+const ratingClass = (rating: number) => {
+  if (rating >= 4.7) {
+    return "excellent";
+  }
+  if (rating >= 4.4) {
+    return "good";
+  }
+  if (rating >= 4.0) {
+    return "midium";
+  }
+  return "poor";
+};
+
+const ListingsContent = () => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { query, results, performSearch, isSearching } = useSearch();
+
+  const parsedQuery = useMemo(() => parseSearchParams(searchParams), [searchParams]);
+  const [parsedMinRating, parsedMaxRating] = parsedQuery.ratingRange;
+
+  useEffect(() => {
+    performSearch(parsedQuery);
+  }, [
+    performSearch,
+    parsedQuery.location,
+    parsedQuery.keywords,
+    parsedMinRating,
+    parsedMaxRating,
+  ]);
+
+  const handleSearch = (values: SearchFormValues) => {
+    const params = createSearchParams(values);
+    router.push(`/listings?${params.toString()}`);
+  };
+
+  const categoryLookup = useMemo(() => {
+    const entries = landingCategories.map((category, index) => [
+      category.id,
+      {
+        icon: category.icon,
+        name: category.name,
+        style: `cats-${(index % 10) + 1}`,
+      },
+    ] as const);
+
+    return new Map(entries);
+  }, []);
+
+  const businessResults = results.length ? results : landingBusinesses;
+  const showEmptyState =
+    !isSearching &&
+    results.length === 0 &&
+    Boolean(query.location.trim() || query.keywords.trim());
+
+  const summaryKeywords = query.keywords || "all services";
+  const summaryLocation = query.location || "all locations";
+
+  return (
+    <>
+      <NavbarUnauthenticated />
+
+      <div
+        className="image-cover hero-banner bg-primary"
+        style={{ backgroundImage: "url('/img/banner-6.jpg')" }}
+        data-overlay="5"
+      >
+        <div className="container">
+          <div className="row justify-content-center align-items-center">
+            <div className="col-xl-12 col-lg-12 col-md-12 col-sm-12">
+              <div className="position-relative text-start mt-4 text-white">
+                <h2 className="fw-semibold">Discover listings tailored to your search</h2>
+                <p className="fs-5 fw-light text-white-50">
+                  Explore curated results from QTick and connect with trusted partners in seconds.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="position-relative d-flex flex-column mt-n3 z-2">
+        <div className="container">
+          <div className="row align-items-center justify-content-center">
+            <div className="col-xl-11 col-lg-12 col-md-12 col-12">
+              <SearchForm onSearch={handleSearch} />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <section>
+        <div className="container">
+          <div className="row align-items-center justify-content-between mb-4">
+            <div className="col-xl-7 col-lg-8 col-md-12">
+              <h5 className="mb-1 fw-semibold">
+                Showing {results.length || landingBusinesses.length} {results.length === 1 ? "listing" : "listings"}
+              </h5>
+              <p className="text-secondary mb-0">
+                Filtering for <strong>{summaryKeywords}</strong> in <strong>{summaryLocation}</strong>
+                {!isDefaultRatingRange(query.ratingRange) && (
+                  <>
+                    {" "}with ratings between {query.ratingRange[0].toFixed(1)}★ and {" "}
+                    {query.ratingRange[1].toFixed(1)}★
+                  </>
+                )}
+              </p>
+            </div>
+            <div className="col-xl-5 col-lg-4 col-md-12 text-md-end mt-3 mt-lg-0">
+              <button
+                type="button"
+                className="btn btn-sm btn-outline-secondary"
+                onClick={() => router.push("/grid-layout-01")}
+              >
+                Preview classic grid layout
+              </button>
+            </div>
+          </div>
+
+          {showEmptyState ? (
+            <div className="alert alert-warning" role="status">
+              No listings matched your filters. Try adjusting your keywords or lowering the minimum rating.
+            </div>
+          ) : (
+            <div className="row align-items-center justify-content-center g-xl-4 g-3">
+              {businessResults.map((business) => {
+                const primaryCategory = business.categories[0];
+                const categoryMeta = primaryCategory ? categoryLookup.get(primaryCategory) : undefined;
+                const CategoryIcon = categoryMeta?.icon;
+                const categoryName = categoryMeta?.name ?? "Featured";
+                const categoryStyle = categoryMeta?.style ?? "";
+
+                return (
+                  <div className="col-xl-6 col-lg-6 col-md-6 col-sm-12 col-12" key={business.id}>
+                    <div className="listingitem-container">
+                      <div className="singlelisting-item">
+                        <div className="listing-top-item">
+                          <Link
+                            href={`/single-listing-01?listing=${business.slug}`}
+                            className="topLink"
+                            aria-label={`View details for ${business.name}`}
+                          >
+                            <div className="position-absolute start-0 top-0 ms-3 mt-3 z-2">
+                              <div className="d-flex align-items-center justify-content-start gap-2 flex-wrap">
+                                <span className="badge badge-xs text-uppercase listOpen">
+                                  {business.isPaid ? "Featured" : "Verified"}
+                                </span>
+                                <span className="badge badge-xs badge-transparent">
+                                  <BsStar className="me-1" aria-hidden={true} />
+                                  {business.rating.toFixed(1)}★
+                                </span>
+                              </div>
+                            </div>
+                            <Image
+                              src={business.heroImage}
+                              width={600}
+                              height={420}
+                              sizes="(max-width: 768px) 100vw, 50vw"
+                              style={{ width: "100%", height: "100%" }}
+                              className="img-fluid"
+                              alt={business.name}
+                            />
+                          </Link>
+                          <div className="position-absolute end-0 bottom-0 me-3 mb-3 z-2">
+                            <Link
+                              href={`/single-listing-01?listing=${business.slug}`}
+                              className="bookmarkList"
+                              data-bs-toggle="tooltip"
+                              data-bs-title="Save Listing"
+                              aria-label={`Save ${business.name}`}
+                            >
+                              <BsSuitHeart className="m-0" />
+                            </Link>
+                          </div>
+                        </div>
+                        <div className="listing-middle-item">
+                          <div className="listing-avatar">
+                            <div className="avatarImg d-flex align-items-center justify-content-center bg-white">
+                              {CategoryIcon ? <CategoryIcon aria-hidden={true} size={22} /> : <BsPatchCheckFill />}
+                            </div>
+                          </div>
+                          <div className="listing-details">
+                            <h4 className="listingTitle">
+                              <Link href={`/single-listing-01?listing=${business.slug}`} className="titleLink">
+                                {business.name}
+                                <span className="verified">
+                                  <BsPatchCheckFill className="m-0" aria-hidden={true} />
+                                </span>
+                              </Link>
+                            </h4>
+                            <p>{business.tagline}</p>
+                          </div>
+                          <div className="listing-info-details">
+                            <div className="d-flex align-items-center justify-content-start gap-2">
+                              <div className="list-distance">
+                                <BsGeoAlt className="mb-0 me-2" aria-hidden={true} />
+                                {business.location}
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div className="listing-footer-item">
+                          <div className="d-flex align-items-center justify-content-between gap-2">
+                            <div className="catdWraps">
+                              <div className="flex-start">
+                                <span className={`catIcon ${categoryStyle}`}>
+                                  {CategoryIcon ? (
+                                    <CategoryIcon aria-hidden={true} size={18} />
+                                  ) : (
+                                    <BsSearch aria-hidden={true} size={18} />
+                                  )}
+                                </span>
+                                <span className="catTitle ms-2">{categoryName}</span>
+                              </div>
+                            </div>
+                            <div className="listing-rates">
+                              <div className="d-flex align-items-center justify-content-start gap-1">
+                                <span className={`ratingAvarage ${ratingClass(business.rating)}`}>
+                                  {business.rating.toFixed(1)}
+                                </span>
+                                <span className="overallrates">{business.reviewCount} reviews</span>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </section>
+
+      <Footer />
+      <BackToTop />
+    </>
+  );
+};
+
+const ListingsPage = () => (
+  <SearchProvider dataset={landingBusinesses}>
+    <ListingsContent />
+  </SearchProvider>
+);
+
+export default ListingsPage;

--- a/src/app/listings/page.tsx
+++ b/src/app/listings/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo } from "react";
+import { Suspense, useEffect, useMemo } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -266,9 +266,22 @@ const ListingsContent = () => {
   );
 };
 
+const ListingsFallback = () => (
+  <>
+    <NavbarUnauthenticated />
+    <div className="container py-5 my-5 text-center" role="status" aria-live="polite">
+      <div className="spinner-border text-primary" role="presentation" aria-hidden={true} />
+      <p className="mt-3 mb-0 fw-medium text-secondary">Loading listings…</p>
+    </div>
+    <Footer />
+  </>
+);
+
 const ListingsPage = () => (
   <SearchProvider dataset={landingBusinesses}>
-    <ListingsContent />
+    <Suspense fallback={<ListingsFallback />}>
+      <ListingsContent />
+    </Suspense>
   </SearchProvider>
 );
 

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -8,7 +8,7 @@ export default function TermsPage() {
           <div className="col-lg-8">
             <h1 className="fw-bold mb-4">Terms &amp; Conditions</h1>
             <p className="text-secondary">
-              Welcome to Qtick Biz Profile. These terms outline the rules and regulations for the use of our website and services. By accessing or using Qtick, you agree to comply with these terms.
+              Welcome to QTick. These terms outline the rules and regulations for the use of our website and services. By accessing or using QTick, you agree to comply with these terms.
             </p>
             <h2 className="h4 mt-4">1. Vendor Responsibilities</h2>
             <p className="text-secondary">
@@ -20,7 +20,7 @@ export default function TermsPage() {
             </p>
             <h2 className="h4 mt-4">3. Payments &amp; Promotions</h2>
             <p className="text-secondary">
-              Paid promotions and featured placements are clearly labelled. All promotional content must follow Qtick&apos;s advertising guidelines.
+              Paid promotions and featured placements are clearly labelled. All promotional content must follow QTick&apos;s advertising guidelines.
             </p>
             <h2 className="h4 mt-4">4. Privacy</h2>
             <p className="text-secondary">

--- a/src/app/types/models.ts
+++ b/src/app/types/models.ts
@@ -130,6 +130,7 @@ export interface Business {
 export interface SearchFormValues {
   location: string;
   keywords: string;
+  ratingRange: [number, number];
 }
 
 export interface SearchContextValue {

--- a/src/app/utils/search.ts
+++ b/src/app/utils/search.ts
@@ -1,0 +1,148 @@
+import type { Business, SearchFormValues } from "../types/models";
+
+type ParamReader = {
+  get: (name: string) => string | null;
+};
+
+type ParamRecord = Record<string, string | string[] | undefined>;
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+const normaliseText = (value: string) => value.trim().toLowerCase();
+
+export const DEFAULT_RATING_RANGE: [number, number] = [0, 5];
+
+const normaliseRange = (range?: [number, number]): [number, number] => {
+  if (!range) {
+    return [...DEFAULT_RATING_RANGE];
+  }
+
+  const [start, end] = range;
+  const min = clamp(Math.min(start, end), DEFAULT_RATING_RANGE[0], DEFAULT_RATING_RANGE[1]);
+  const max = clamp(Math.max(start, end), DEFAULT_RATING_RANGE[0], DEFAULT_RATING_RANGE[1]);
+
+  return [min, max];
+};
+
+export const createDefaultSearchValues = (): SearchFormValues => ({
+  location: "",
+  keywords: "",
+  ratingRange: [...DEFAULT_RATING_RANGE],
+});
+
+const readParam = (source: ParamReader | ParamRecord | undefined, key: string): string | null => {
+  if (!source) {
+    return null;
+  }
+
+  if (typeof (source as ParamReader).get === "function") {
+    return (source as ParamReader).get(key);
+  }
+
+  const value = (source as ParamRecord)[key];
+  if (Array.isArray(value)) {
+    return value.length ? value[0] ?? null : null;
+  }
+
+  return value ?? null;
+};
+
+const parseNumber = (value: string | null, fallback: number) => {
+  if (value === null || value === undefined) {
+    return fallback;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+};
+
+export const parseSearchParams = (
+  params?: ParamReader | ParamRecord
+): SearchFormValues => {
+  const location = (readParam(params, "location") ?? "").trim();
+  const keywords = (readParam(params, "keywords") ?? "").trim();
+
+  const minRatingRaw = parseNumber(readParam(params, "minRating"), DEFAULT_RATING_RANGE[0]);
+  const maxRatingRaw = parseNumber(readParam(params, "maxRating"), DEFAULT_RATING_RANGE[1]);
+  const ratingRange = normaliseRange([minRatingRaw, maxRatingRaw]);
+
+  return {
+    location,
+    keywords,
+    ratingRange,
+  };
+};
+
+export const filterBusinesses = (
+  values: SearchFormValues,
+  dataset: Business[]
+): Business[] => {
+  const locationTerm = normaliseText(values.location);
+  const keywordTerm = normaliseText(values.keywords);
+  const [minRating, maxRating] = normaliseRange(values.ratingRange);
+
+  return dataset.filter((business) => {
+    const matchesLocation =
+      !locationTerm || normaliseText(business.location).includes(locationTerm);
+
+    if (!matchesLocation) {
+      return false;
+    }
+
+    if (keywordTerm) {
+      const keywordSources = [
+        business.name,
+        business.tagline,
+        business.description,
+        business.categories.join(" "),
+      ].map(normaliseText);
+
+      const matchesKeywords = keywordSources.some((source) => source.includes(keywordTerm));
+
+      if (!matchesKeywords) {
+        return false;
+      }
+    }
+
+    const withinRating = business.rating >= minRating && business.rating <= maxRating;
+
+    return withinRating;
+  });
+};
+
+export const createSearchParams = (values: SearchFormValues) => {
+  const params = new URLSearchParams();
+
+  const location = values.location.trim();
+  const keywords = values.keywords.trim();
+  const [minRating, maxRating] = normaliseRange(values.ratingRange);
+
+  if (location) {
+    params.set("location", location);
+  }
+
+  if (keywords) {
+    params.set("keywords", keywords);
+  }
+
+  if (minRating > DEFAULT_RATING_RANGE[0]) {
+    params.set("minRating", minRating.toString());
+  }
+
+  if (maxRating < DEFAULT_RATING_RANGE[1]) {
+    params.set("maxRating", maxRating.toString());
+  }
+
+  return params;
+};
+
+export const isDefaultRatingRange = (range: [number, number]) => {
+  const [minRating, maxRating] = normaliseRange(range);
+  return minRating === DEFAULT_RATING_RANGE[0] && maxRating === DEFAULT_RATING_RANGE[1];
+};
+
+export const normaliseSearchValues = (values: SearchFormValues): SearchFormValues => ({
+  location: values.location.trim(),
+  keywords: values.keywords.trim(),
+  ratingRange: normaliseRange(values.ratingRange),
+});

--- a/src/app/vendor/[id]/page.tsx
+++ b/src/app/vendor/[id]/page.tsx
@@ -29,12 +29,12 @@ export async function generateMetadata({
   const vendor = getVendorBySlug(id);
   if (!vendor) {
     return {
-      title: "Vendor not found | Qtick",
+      title: "Vendor not found | QTick",
     };
   }
 
   return {
-    title: `${vendor.name} | Qtick Vendor Profile`,
+    title: `${vendor.name} | QTick Vendor Profile`,
     description: vendor.tagline,
   };
 }


### PR DESCRIPTION
## Summary
- restyle the landing hero search to mirror Home Layout 09, add a rating slider, and route submissions to the listings experience
- introduce shared search utilities and build a listings page that mirrors Grid Layout 01 alongside a consolidated demo index
- refresh branding to “QTick”, remove the sponsored highlight, extend the hero height, and add a logo placeholder-powered navigation brand

## Testing
- npm run lint *(fails: command prompts for interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68c90518d510832e9924604afe2de51f